### PR TITLE
made clear-button undoable

### DIFF
--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,4 +1,4 @@
-const c = document.getElementById("canv");
+        const c = document.getElementById("canv");
         const ctx = c.getContext("2d");
         const offsetX = c.getBoundingClientRect().left;
         const offsetY = c.getBoundingClientRect().top;
@@ -28,8 +28,12 @@ const c = document.getElementById("canv");
         var currentStateIndex = -1;
     
         function resetStates() {
-                states = [];
-                currentStateIndex = -1;
+            // delete all states after currentStateIndex to avoid bug
+            var states_new = [];
+            for(var i = 0; i <= currentStateIndex; i++) {
+                states_new[i] = states[i]
+            }
+            states = states_new;
         }
         
         


### PR DESCRIPTION
Resolves #14 
---
Description:
- This pull request implements undo functionality for the canvas clear button feature. Previously, clicking the clear button would erase the entire canvas without the ability to revert the action. With this update, users can now undo the clear action using the undo feature.

Changes:
- Added undo functionality to revert canvas clear action
- changed resetStates() function to fix the following bug (if we would just say state = [] ):
  - when you undo 2+ times and clear after that, then you could use the redo button and a wrong state would be shown.