### PR TITLE
Added option to create multiple images

### DIFF
--- a/backend/t2i-adapter.py
+++ b/backend/t2i-adapter.py
@@ -2,16 +2,14 @@ from diffusers import StableDiffusionXLAdapterPipeline, T2IAdapter, EulerAncestr
 from diffusers.utils import load_image, make_image_grid
 from controlnet_aux.pidi import PidiNetDetector
 import torch
+import argparse
 
-# load adapter
-adapter = T2IAdapter.from_pretrained(
-  "TencentARC/t2i-adapter-sketch-sdxl-1.0", torch_dtype=torch.float16, varient="fp16").to("cuda")
 
 #links to the huggingface website on which the sdxl files are located
-photographyID = "f0ster/PhotographyLoRA"  
+photographyID = "f0ster/PhotographyLoRA"
 embroideryID = "ostris/embroidery_style_lora_sdxl"
 origamiID = "RalFinger/origami-style-sdxl-lora"
-animeID = "Linaqruf/pastel-anime-xl-lora" 
+animeID = "Linaqruf/pastel-anime-xl-lora"
 watercolorID = "ostris/watercolor_style_lora_sdxl"
 crayonsID = "ostris/crayon_style_lora_sdxl"
 
@@ -20,36 +18,87 @@ photographyName = "photography-lora-xl_10.safetensors"
 embroideryName = "embroidered_style_v1_sdxl.safetensors"
 origamiName = "ral-orgmi-sdxl.safetensors"
 animeName = "pastel-anime-xl-latest.safetensors"
-watercolorName = "watercolor_v1_sdxl.safetensors" 
+watercolorName = "watercolor_v1_sdxl.safetensors"
 crayonsName = "crayons_v1_sdxl.safetensors"
 
-#Change modelID and modelName to get a different style
-modelID = watercolorID
-modelName = watercolorName
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--num_of_images', type=int, default=1, help='')
+    parser.add_argument('--num_inference_steps', type=int, default=30, help='')
+    parser.add_argument("--adapter_conditioning_scale", type=float, default=0.6, help='')
+    parser.add_argument("--guidance_scale", type=float, default=7.5, help='')
+    parser.add_argument("--style", type=str, default=None, help='')        
 
-# load euler_a scheduler
-model_id = 'stabilityai/stable-diffusion-xl-base-1.0'
-euler_a = EulerAncestralDiscreteScheduler.from_pretrained(model_id, subfolder="scheduler")
-vae=AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16)
-pipe = StableDiffusionXLAdapterPipeline.from_pretrained(
-    model_id, vae=vae, adapter=adapter, scheduler=euler_a, torch_dtype=torch.float16, variant="fp16",
-).to("cuda")
-pipe.enable_xformers_memory_efficient_attention()
+    args = parser.parse_args()
+    styles = args.style
+    print(styles)
+    match styles:
+        case "Watercolor":
+             modelID = watercolorID
+             modelName = watercolorName
+        case "Photography":
+            modelID = photographyID
+            modelName = photographyName
+        case "Embroidery":
+            modelID = embroideryID
+            modelName = embroideryName
+        case "Crayon":
+            modelID = crayonsID
+            modelName = crayonsName
+        case "Origami":
+            modelID = origamiID
+            modelName = origamiName
+        case "Anime":
+            modelID = animeID
+            modelName = animeName  
+    return args
 
-#loads image that will be used as the sketch
-image = load_image("test_pics/house.png")
+def run(args):
 
-#loads the chosen style by the user
-pipe.load_lora_weights(modelID, weight_name=modelName)
-prompt = "house on lake, Mount Fuji in the background, sunset, realistic, 4k"
-negative_prompt = "extra digit, fewer digits, cropped, worst quality, low quality, glitch, deformed, mutated, ugly, disfigured"
+    # load adapter
+    adapter = T2IAdapter.from_pretrained(
+      "TencentARC/t2i-adapter-sketch-sdxl-1.0", torch_dtype=torch.float16, varient="fp16").to("cuda")
 
-gen_images = pipe(
-    prompt=prompt,
-    negative_prompt=negative_prompt,
-    image=image,
-    num_inference_steps=30,
-    adapter_conditioning_scale=0.6,
-    guidance_scale=7.5,
-).images[0]
-gen_images.save('test_pics/house_anime_test.png')
+    #Change modelID and modelName to get a different style
+    modelID = watercolorID
+    modelName = watercolorName
+
+    # load euler_a scheduler
+    model_id = 'stabilityai/stable-diffusion-xl-base-1.0'
+    euler_a = EulerAncestralDiscreteScheduler.from_pretrained(model_id, subfolder="scheduler")
+    vae=AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16)
+    pipe = StableDiffusionXLAdapterPipeline.from_pretrained(
+        model_id, vae=vae, adapter=adapter, scheduler=euler_a, torch_dtype=torch.float16, variant="fp16",
+    ).to("cuda")
+    pipe.enable_xformers_memory_efficient_attention()
+
+    #loads image that will be used as the sketch
+    image = load_image("test_pics/house.png")
+    #amount of images that will be generated
+    amountOfImages = args.num_of_images 
+    if amountOfImages > 4:
+      amountOfImages = 4
+    if amountOfImages < 0:
+      amountOfImages = 1
+    #loads the chosen style by the user
+    pipe.load_lora_weights(modelID, weight_name=modelName)
+    prompt = "house on lake, Mount Fuji in the background, sunset, realistic, 4k"
+    negative_prompt = "extra digit, fewer digits, cropped, worst quality, low quality, glitch, deformed, mutated, ugly, disfigured"
+    while amountOfImages > 0:
+      amountOfImages -= 1
+      gen_images = pipe(
+         prompt=prompt,
+         negative_prompt=negative_prompt,
+         image=image,
+         num_inference_steps=args.num_inference_steps,
+         adapter_conditioning_scale=args.adapter_conditioning_scale,
+         guidance_scale=args.guidance_scale,
+         ).images[0]
+      gen_images.save('test_pics/generate_more_images_test' + str(amountOfImages) + '.png')
+
+def main():
+    args = get_args()
+    run(args)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
resolves #30 

User can now choose the amount of images that should be created. This can be accessed in the script with '--num_of_images *number of images to be created*'. The number of images is limited to 4 in order to avoid long loading times.