### PR TITLE
added tooltip to get explanation of advanced option

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -85,34 +85,34 @@
         <div id="advanced-dropdown-content">
 
             <div class="negPrompt-container">
-                <p id="detaiText">Negative Prompt:</p>
+                <p id="detaiText" data-tooltip="Enter a negative prompt to specify what you don't want to see in the generated image.">Negative Prompt:</p>
                 <textarea id="negPrompt" placeholder="Enter negative prompt here...">extra digit, fewer digits, cropped, worst quality, low quality, glitch, deformed, mutated, ugly, disfigured</textarea>
             </div>
 
             <div class="slider-container">
                 <div class="detail-container">
-                    <p id="detaiText">Number of steps: <span id="detailValue">25</span></p>
+                    <p id="detaiText" data-tooltip="Adjust the number of steps to control the level of detail in the generated image. A higher value means more detailed results.">Number of steps: <span id="detailValue">25</span></p>
                     <span class="slider-label">0</span>
                     <input title="increase / decrease detail value" type="range" min="0" max="50" value="25" step="1" class="slider" id="detailSlider">
                     <span class="slider-label">50</span>
                 </div>
                 
                 <div class="p-container">
-                    <p id="detaiText">Guidance scale: <span id="pValue">7.5</span></p>
+                    <p id="detaiText" data-tooltip="Adjust the guidance scale to control how closely the generated image follows the prompt. A higher value means the image will be more closely related to the prompt.">Guidance scale: <span id="pValue">7.5</span></p>
                     <span class="slider-label">0</span>
                     <input title="Prompt" type="range" min="0" max="15" value="7.5" step="0.5" class="slider" id="pSlider">
                     <span class="slider-label">15</span>
                 </div>
 
                 <div class="s-container">
-                    <p id="detaiText">Adapter conditioning scale: <span id="sValue">0.6</span></p>
+                    <p id="detaiText" data-tooltip="Adjust the adapter conditioning scale to control how much the generated image is influenced by the adapter. A higher value means the image will be more closely related to the adapter.">Adapter conditioning scale: <span id="sValue">0.6</span></p>
                     <span class="slider-label">0</span>
                     <input title="Sketch" type="range" min="0" max="1" value="0.6" step="0.1" class="slider" id="sSlider">
                     <span class="slider-label">1</span>
                 </div>
 
                 <div>
-                    <p id="detaiText">Amount of generated images: <span id="MIValue">1</span></p>
+                    <p id="detaiText" data-tooltip="Select the number of images to generate. A higher value means more images will be generated.">Amount of generated images: <span id="MIValue">1</span></p>
                     <span class=""slider-label>1</span>
                     <input title="multiple images" type="range" min="1" max="4" value="1" step="1" class="slider" id="MISlider">
                     <span class=""slider-label>4</span>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -470,3 +470,34 @@ document.getElementById("fileInput").addEventListener("change", function(event) 
         reader.readAsDataURL(file);
     }
 });
+
+// Add event listeners to all elements with a data-tooltip attribute
+document.querySelectorAll('[data-tooltip]').forEach(element => {
+    element.addEventListener('mouseover', event => {
+        // Create a tooltip element
+        let tooltip = document.createElement('div');
+        tooltip.className = 'tooltip';
+        tooltip.innerHTML = element.getAttribute('data-tooltip');
+
+        // Add the tooltip to the body
+        document.body.appendChild(tooltip);
+
+        // Set the tooltip's position
+        let rect = element.getBoundingClientRect();
+        tooltip.style.position = 'absolute';
+        tooltip.style.top = `${rect.top + window.scrollY - tooltip.offsetHeight}px`;
+        tooltip.style.left = `${rect.left + window.scrollX}px`;
+
+        // Show the tooltip
+        tooltip.style.visibility = 'visible';
+        tooltip.style.opacity = '1';
+    });
+
+    element.addEventListener('mouseout', event => {
+        // Remove the tooltip
+        let tooltip = document.querySelector('.tooltip');
+        if (tooltip) {
+            tooltip.remove();
+        }
+    });
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -457,4 +457,22 @@ body {
     right: 15%; */
 }
 
+/*show explanation of advanced options */
+.tooltip {
+    position: absolute;
+    background-color: #ccc;
+    border: 1px solid #aaa;
+    padding: 5px;
+    font-size: 14px;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.3s;
+    z-index: 1000;
+    border-radius: 5px;
+}
+
+.tooltip:hover {
+    visibility: visible;
+    opacity: 1;
+}
 


### PR DESCRIPTION
Resolves #89 

Added Tooltip. So when user moves the mouse pointer over an advanced option it will show an explanation of this option.
Here is an example: 
![image](https://github.com/user-attachments/assets/93b6350a-b944-4c08-9913-a29c6fbb8147)
